### PR TITLE
Bump solidjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "remark-cli": "11.0.0",
         "remark-preset-lint-recommended": "6.1.2",
         "sass": "1.58.3",
-        "solid-js": "1.6.13",
+        "solid-js": "1.7.2",
         "stylelint-config-web-scrobbler": "0.2.0",
         "tsx": "3.12.5",
         "typescript": "4.9.5",
@@ -9626,6 +9626,14 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/seroval": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-0.5.1.tgz",
+      "integrity": "sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9697,11 +9705,12 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.6.13.tgz",
-      "integrity": "sha512-/zcyeect3QnmcD58754IpOU/SzX3s9N19RlRVoKRz3tNpzvel7QKO4FX/PpIFQH6n/pxWq6rSh6b9fwe20XUvw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.7.2.tgz",
+      "integrity": "sha512-01f8GIc+HTTlfDXtK+TFku3AllHyJ3hNsIpxM2qpObRP4VbEGVIP6VbULnThPlpse+J1y/I/1N9QeQ9MNkE8Ow==",
       "dependencies": {
-        "csstype": "^3.1.0"
+        "csstype": "^3.1.0",
+        "seroval": "^0.5.0"
       }
     },
     "node_modules/solid-refresh": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "homepage": "https://web-scrobbler.com/",
   "dependencies": {
     "@suid/icons-material": "0.5.9",
-    "blueimp-md5": "2.19.0",
     "@web-scrobbler/metadata-filter": "3.0.1",
+    "blueimp-md5": "2.19.0",
     "stylelint": "13.13.1",
     "vite": "4.1.4",
     "webextension-polyfill": "0.10.0"
@@ -59,7 +59,7 @@
     "remark-cli": "11.0.0",
     "remark-preset-lint-recommended": "6.1.2",
     "sass": "1.58.3",
-    "solid-js": "1.6.13",
+    "solid-js": "1.7.2",
     "stylelint-config-web-scrobbler": "0.2.0",
     "tsx": "3.12.5",
     "typescript": "4.9.5",


### PR DESCRIPTION
The issue that occured was that for some reason some dependency of SolidJS updated in a way that caused SolidJS to break. Bumping SolidJS to 1.7.2 fixed the issue.